### PR TITLE
Safer error unwrapping

### DIFF
--- a/Sources/BleWrapper/BleWrapper.swift
+++ b/Sources/BleWrapper/BleWrapper.swift
@@ -70,7 +70,7 @@ open class BleWrapper {
 
 /// Async implementations
 extension BleWrapper {
-    open func openAppIfNeeded(_ name: String) async throws {
+    public func openAppIfNeeded(_ name: String) async throws {
         do {
             return try await BleTransport.shared.openAppIfNeeded(name)
         } catch {
@@ -78,7 +78,7 @@ extension BleWrapper {
         }
     }
     
-    open func getAppAndVersion() async throws -> AppInfo {
+    public func getAppAndVersion() async throws -> AppInfo {
         do {
             return try await BleTransport.shared.getAppAndVersion()
         } catch {

--- a/Sources/BleWrapper/BridgeError.swift
+++ b/Sources/BleWrapper/BridgeError.swift
@@ -16,7 +16,7 @@ public struct BridgeError: Error {
     
     // MARK: - Static methods
     public static func fromJSValue(_ jsValue: JSValue) -> Error {
-        guard let dict = jsValue.toDictionary() else { return BleTransportError.lowerLevelError(description: jsValue.debugDescription) }
+        guard jsValue.isObject, let dict = jsValue.toDictionary() else { return BleTransportError.lowerLevelError(description: jsValue.debugDescription) }
         guard let name = dict["name"] as? String else { return BleTransportError.lowerLevelError(description: jsValue.debugDescription) }
         guard let message = dict["message"] as? String else { return BleTransportError.lowerLevelError(description: jsValue.debugDescription) }
         


### PR DESCRIPTION
- Fixes an issue where an exception is logged when trying to convert a `String` type JSValue to a dictionary.
- Fixes a few warnings `Non-'@objc' instance method in extensions cannot be overridden; use 'public' instead`